### PR TITLE
feat!: migrating away from Bitnami

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,12 @@ locals {
   }
 
   addon_values = yamlencode({
+    global = {
+      rbac = {
+        create = module.addon-irsa[local.addon.name].rbac_create
+      }
+    }
+
     prometheus = {
       serviceAccount = {
         create = module.addon-irsa[local.addon.name].service_account_create


### PR DESCRIPTION
# Description
:warning: BREAKING CHANGES!
We are moving away from Bitnami chart and images. This PR uses prometheus community helm chart and Quay.io images. 

This PR upgrades application versions:
prometheus-operator -  0.76.1 -> 0.83.0
prometheus - 2.54.0 -> 3.5.0 BREAKING CHANGE ⚠️  check [migration guide](https://prometheus.io/docs/prometheus/latest/migration/)
node-exporter - 1.8.2 -> 1.9.1 
kube-state-metrics - 2.13.0 -> 2.16.0
blackbox-exporter - BREAKING CHANGE ⚠️ integration removed in the new chart

This PR completely changes values integration to support the [new chart](https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-75.13.0/charts/kube-prometheus-stack). Check the new values.yaml schema [here](https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-75.13.0/charts/kube-prometheus-stack/values.yaml).

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?


<!--
Please describe the tests that you ran to verify your changes.
-->
