### PR TITLE
fix: fixing helm chart name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
 */
 locals {
   addon = {
-    name      = "kube-prometheus"
+    name      = "kube-prometheus-stack"
     namespace = "prometheus"
 
     helm_repo_url      = "https://prometheus-community.github.io/helm-charts"


### PR DESCRIPTION
# Description
Building up on https://github.com/lablabs/terraform-aws-eks-prometheus/pull/17. Tjis PR fixes incorrect helm chart name which was being overridden from integration.

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->
